### PR TITLE
Update pr-enforce-labels.yaml - type::docs

### DIFF
--- a/.github/workflows/pr-enforce-labels.yaml
+++ b/.github/workflows/pr-enforce-labels.yaml
@@ -11,5 +11,5 @@ jobs:
       with:
         mode: exactly
         count: 1
-        labels: "type::security, type::feature, type::bug, type::chore"
+        labels: "type::security, type::feature, type::bug, type::chore, type::docs"
 


### PR DESCRIPTION
Allow `type::docs` as a valid label. Common for PR's on their own to just be docs updates.