### PR TITLE
TF workflow deprecations

### DIFF
--- a/.github/workflows/_validate.yaml
+++ b/.github/workflows/_validate.yaml
@@ -10,10 +10,10 @@ jobs:
   validate:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16
+          node-version: 20
       - name: Validate workflows
         run: |
           npm ci

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Download plan
         uses: actions/download-artifact@v3

--- a/.github/workflows/terraform-apply.yaml
+++ b/.github/workflows/terraform-apply.yaml
@@ -53,13 +53,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Download plan
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{ inputs.planName }}
           path: ${{ inputs.envPath }}
 
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.4.6
 

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup terraform
         uses: hashicorp/setup-terraform@v2

--- a/.github/workflows/terraform-plan.yaml
+++ b/.github/workflows/terraform-plan.yaml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Setup terraform
-        uses: hashicorp/setup-terraform@v2
+        uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: 1.4.6
 
@@ -64,7 +64,7 @@ jobs:
              terraform plan -out=${{ inputs.planName }}
 
       - name: 'Upload Plan'
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ inputs.planName }}
           path: ${{ inputs.envPath }}/${{ inputs.planName }}

--- a/.github/workflows/terraform-test.yaml
+++ b/.github/workflows/terraform-test.yaml
@@ -38,7 +38,7 @@ jobs:
   #
   #   steps:
   #     - name: Checkout repo
-  #       uses: actions/checkout@v2
+  #       uses: actions/checkout@v4
   #
   #     - name: Run checkov scan on ${{ inputs.envPath }}
   #       run: checkov --quiet --compact -d ${{ inputs.envPath }}
@@ -50,7 +50,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run terraform fmt
         run: terraform fmt -recursive -check -diff
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Run terraform validate
         env:


### PR DESCRIPTION
* `actions/checkout@v2` & `actions/checkout@v3` -> `actions/checkout@v4`
* `actions/setup-node@v3` -> `actions/setup-node@v4`
* `node-version: 16` -> `node-version: 20`
* `actions/upload-artifact@v3` -> `actions/upload-artifact@v4`
* `actions/download-artifact@v3` -> `actions/download-artifact@v4`
* `hashicorp/setup-terraform@v2` -> `hashicorp/setup-terraform@v3`

---

Tested in https://github.com/replicatedhq/replicated-terraform/actions/runs/10708508888/job/29690996480 where reusable workflows we're set to commit `42365d1217eca5cf4b6cbd6f732187e10110257d` here.

